### PR TITLE
Fix the re and tarfile fuzzers

### DIFF
--- a/re.py
+++ b/re.py
@@ -3,7 +3,7 @@ import re
 def FuzzerRunOne(FuzzerInput):
     try:
         re.purge()
-        re.compile(FuzzerInput.decode("utf-8", "replace"), re.IGNORECASE | re.LOCALE | re.MULTILINE | re.VERBOSE)
+        re.compile(FuzzerInput.decode("utf-8", "replace"), re.IGNORECASE | re.MULTILINE | re.VERBOSE)
     except re.error:
         return
 

--- a/tarfile.py
+++ b/tarfile.py
@@ -3,7 +3,7 @@ import tarfile
 
 def FuzzerRunOne(FuzzerInput):
     try:
-        with tarfile.open(io.BytesIO(FuzzerInput), ignore_zeros=True, errorlevel=0) as tf:
+        with tarfile.open(fileobj=io.BytesIO(FuzzerInput), ignore_zeros=True, errorlevel=0) as tf:
             for tarinfo in tf:
                 tarinfo.name
                 tarinfo.size


### PR DESCRIPTION
- tarfile isn't smart enough to differentiate between paths and fileobj, so we need to explicitly name the parameter to pass a BytesIO instance
- re doesn't like the LOCALE flat when used on strings.